### PR TITLE
Add view for history of texts with a user phone #

### DIFF
--- a/app/controllers/internal_controller.rb
+++ b/app/controllers/internal_controller.rb
@@ -3,4 +3,11 @@ class InternalController < ApplicationController
 
   def index
   end
+
+  def phone_number
+    @phone_number = params[:number]
+    number_for_sql = '+' + @phone_number
+    m = Message.arel_table
+    @messages = Message.where(m[:to_number].eq(number_for_sql).or(m[:from_number].eq(number_for_sql))).order('date_sent ASC')
+  end
 end

--- a/app/views/incoming/index.erb
+++ b/app/views/incoming/index.erb
@@ -13,7 +13,7 @@
     <% else %>
       <% clean_body = m.body %>
     <% end %>
-    <%= "#{m.from_number} — #{m.date_sent} — #{@phone_number_hash[m.to_number]} — #{clean_body}" %>
+    <a href="/internal/phone-numbers/<%= m.from_number.gsub("+","") %>"><%= m.from_number %></a> — <%= "#{m.date_sent} — #{@phone_number_hash[m.to_number]} — #{clean_body}" %>
   </li>
 <% end %>
 </ul>

--- a/app/views/internal/phone_number.erb
+++ b/app/views/internal/phone_number.erb
@@ -1,0 +1,122 @@
+<h3><%= @phone_number %></h3>
+
+<a href="/internal/incoming">Back</a>
+
+<header><span class="left"></span><%= @phone_number %><span class="right"></span></header>
+
+<body>
+<div class="messages-wrapper">
+
+<% @messages.each do |m| %>
+  <% direction = m.direction == 'inbound' ? 'from' : 'to' %>
+  <div class="message <%= direction %>"><%= m.body %></div>
+<% end %>
+
+</div>
+</body>
+
+<style>
+@import "http://fonts.googleapis.com/css?family=Open+Sans:400,600,700";
+* {
+    box-sizing: border-box;
+}
+body {
+    background: none repeat scroll 0 0 #fff;
+    color: #FFFFFF;
+    font-family: "Open Sans";
+    line-height: 26px;
+    width: 400px;
+    margin: 0 auto;
+    overflow-X: hidden;
+    position: relative;
+}
+.left {
+  position: absolute;
+  top: 0;
+  left: 35px;
+  font-size: 18px
+}
+
+.left:after {
+    border: 3px solid #2095FE;
+    border-right: 3px solid transparent;
+    border-top: 3px solid transparent;
+    content: " ";
+    height: 14px;
+    left: -20px;
+    position: absolute;
+    top: 20px;
+    -webkit-transform: rotate(45deg);
+  -moz-transform: rotate(45deg);
+  transform: rotate(45deg);
+    width: 14px;
+}
+.right {
+  position: absolute;
+  top: 0;
+  right: 15px;
+  font-size: 18px
+}
+header {
+  color: #2095FE;
+  background: #eee;
+  border: 1px solid #ccc;
+  border-bottom: 1px solid #bbb;
+  box-shadow: 0 1px 2px rgba(1,1,1,0.2);
+  height: 60px;
+  text-align: center;
+  font-size: 20px;
+  line-height: 58px;
+  white-space: nowrap;
+
+}
+header h2 {
+  font-weight: bold;
+  color: #111111;
+}
+.messages-wrapper {
+  padding-top: 10px;
+  position: relative;
+  border: 1px solid #ddd;
+  border-top: 0 none;
+}
+.message {
+    border-radius: 20px 20px 20px 20px;
+    margin: 0 15px 10px;
+    padding: 15px 20px;
+    position: relative;
+}
+.message.to {
+    background-color: #2095FE;
+    color: #fff;
+    margin-left: 80px;
+}
+.message.from {
+    background-color: #E5E4E9;
+    color: #363636;
+    margin-right: 80px;
+}
+.message.to + .message.to,
+.message.from + .message.from {
+  margin-top: -7px;
+}
+.message:before {
+    border-color: #2095FE;
+    border-radius: 50% 50% 50% 50%;
+    border-style: solid;
+    border-width: 0 20px;
+    bottom: 0;
+    clip: rect(20px, 35px, 42px, 0px);
+    content: " ";
+    height: 40px;
+    position: absolute;
+    right: -50px;
+    width: 30px;
+    z-index: -1;
+}
+.message.from:before {
+    border-color: #E5E4E9;
+    left: -50px;
+    transform: rotateY(180deg);
+}
+</style>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ BalanceMetricsV2::Application.routes.draw do
   root 'application#index'
   get 'internal' => 'internal#index'
   get 'internal/incoming' => 'incoming#index'
+  get 'internal/phone-numbers/:number' => 'internal#phone_number'
 
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'


### PR DESCRIPTION
Part of the internal dashboard, can be accessed through the `/incoming` view by clicking on a phone number (see below) or by simply going to the URL `/internal/phone-numbers/14151112222` (dummy phone number there)
## Link from incoming page

![screen shot 2014-12-02 at 3 32 29 pm](https://cloud.githubusercontent.com/assets/994938/5273229/b3bad41e-7a39-11e4-872a-c9cef9b1e1c4.png)
## View of history

![screen shot 2014-12-02 at 3 35 37 pm](https://cloud.githubusercontent.com/assets/994938/5273246/d11153b2-7a39-11e4-90c0-9ca781cbeccd.png)

Closes #16 
