### PR TITLE
add ducksboard metrics routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,9 @@ BalanceMetricsV2::Application.routes.draw do
   get 'internal' => 'internal#index'
   get 'internal/incoming' => 'incoming#index'
   get 'internal/phone-numbers/:number' => 'internal#phone_number'
+  get 'mau' => 'application#mau'
+  get 'monthly_checks' => 'application#monthly_checks'
+  get 'leaderboard' => 'application#leaderboard'
 
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'


### PR DESCRIPTION
Adds three routes for ducksboard:
- /mau
- /monthly_checks
- /leaderboard

To make these:
![screen shot 2014-12-26 at 3 30 15 pm](https://cloud.githubusercontent.com/assets/2533112/5559956/f57656be-8d1a-11e4-8834-0602d591a429.png)

I pulled some common things into a :before_filter but otherwise this doesn't address performance or fix the index page or anything.
